### PR TITLE
Remove std feature and std_root function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
         - cargo test
         - cargo doc --no-deps
         - cd "${TRAVIS_BUILD_DIR}/examples/example"
-        - cargo run --bin example
+        - cargo run --bin example --all-features
 
     - rust: nightly
       name: cargo test (minimal versions)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* Remove `std` feature and `std_root` function<br>
+  `derive_utils` can generate accurate code without `std` feature.
+
 # 0.5.4 - 2019-01-03
 
 * Improve documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,3 @@ proc-macro2 = "^0.4.13"
 quote = "^0.6.8"
 smallvec = "^0.6.7"
 syn = { version = "^0.15.19", features = ["full"] }
-
-[features]
-# Default features.
-default = ["std"]
-# Generate code for `std` library.
-std = []

--- a/README.md
+++ b/README.md
@@ -139,13 +139,6 @@ where
 
 See [auto_enums crate](https://github.com/taiki-e/auto_enums/tree/master/derive/src/derive) for more examples.
 
-## Crate Features
-
-* `std`
-  * Enabled by default.
-  * Generate code for `std` library.
-  * Disable this feature to generate code for `no_std`.
-
 ## Rust Version
 
 The current minimum required Rust version is 1.30.

--- a/examples/example/Cargo.toml
+++ b/examples/example/Cargo.toml
@@ -6,3 +6,6 @@ publish = false
 
 [dependencies]
 example_derive = { path = "../example_derive" }
+
+[features]
+pin = []

--- a/examples/example/src/main.rs
+++ b/examples/example/src/main.rs
@@ -1,17 +1,20 @@
+#![cfg_attr(feature = "pin", feature(futures_api))]
+
 #[macro_use]
 extern crate example_derive;
 
 #[derive(Iterator, ExactSizeIterator, FusedIterator)]
-enum Iter<A, B> {
+#[cfg_attr(feature = "pin", derive(Future))]
+enum Enum<A, B> {
     A(A),
     B(B),
 }
 
 fn return_iter(x: i16) -> impl ExactSizeIterator<Item = i16> {
     if x < 0 {
-        Iter::A(x..=0)
+        Enum::A(x..=0)
     } else {
-        Iter::B(0..x)
+        Enum::B(0..x)
     }
 }
 

--- a/examples/example_derive/src/lib.rs
+++ b/examples/example_derive/src/lib.rs
@@ -45,71 +45,17 @@ pub fn derive_fused_iterator(input: TokenStream) -> TokenStream {
     }
 }
 
-/* Same as the following:
-
-extern crate derive_utils;
-extern crate proc_macro;
-extern crate proc_macro2;
-extern crate syn;
-
-use derive_utils::{derive_trait, EnumData};
-use proc_macro::TokenStream;
-use proc_macro2::{Ident, Span};
-use syn::DeriveInput;
-
-#[proc_macro_derive(Iterator)]
-pub fn derive_iterator(input: TokenStream) -> TokenStream {
-    let ast: DeriveInput = syn::parse(input).unwrap();
-    let data = EnumData::from_derive(&ast).unwrap();
-
-    derive_trait!(
-        data,
-        _,
-        // trait
-        trait Iterator {
-            type Item;
-            fn next(&mut self) -> Option<Self::Item>;
-            fn size_hint(&self) -> (usize, Option<usize>);
-        }
-    )
-    .unwrap()
-    .into()
-}
-
-#[proc_macro_derive(ExactSizeIterator)]
-pub fn derive_exact_size_iterator(input: TokenStream) -> TokenStream {
-    let ast: DeriveInput = syn::parse(input).unwrap();
-    let data = EnumData::from_derive(&ast).unwrap();
-
-    derive_trait!(
-        data,
-        // super trait's associated types
-        Some(Ident::new("Item", Span::call_site())),
-        _,
-        // trait
-        trait ExactSizeIterator: Iterator {
-            fn len(&self) -> usize;
-        }
-    )
-    .unwrap()
-    .into()
-}
-
-#[proc_macro_derive(FusedIterator)]
-pub fn derive_fused_iterator(input: TokenStream) -> TokenStream {
-    let ast: DeriveInput = syn::parse(input).unwrap();
-    let data = EnumData::from_derive(&ast).unwrap();
-
-    derive_trait!(
-        data,
-        // super trait's associated types
-        Some(Ident::new("Item", Span::call_site())),
+#[proc_macro_derive(Future)]
+pub fn derive_future(input: TokenStream) -> TokenStream {
+    quick_derive! {
+        input,
         // path
-        (std::iter::FusedIterator),
+        (std::future::Future),
         // trait
-        trait FusedIterator: Iterator {}
-    )
-    .unwrap()
-    .into()
+        trait Future {
+            type Output;
+            fn poll(self: std::pin::Pin<&mut Self>, lw: &std::task::LocalWaker)
+                -> std::task::Poll<Self::Output>;
+        }
+    }
 }
-*/

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,5 +1,4 @@
-use proc_macro2::{Ident, Span, TokenStream};
-use quote::quote;
+use proc_macro2::{Ident, Span};
 use syn::{punctuated::Punctuated, *};
 
 pub(crate) fn default<T: Default>() -> T {
@@ -35,16 +34,4 @@ pub(crate) fn param_ident(attrs: Vec<Attribute>, ident: Ident) -> GenericParam {
         eq_token: None,
         default: None,
     })
-}
-
-/// Returns standard library's root.
-///
-/// In default returns `::std`.
-/// if disabled default crate feature, returned `::core`.
-pub fn std_root() -> TokenStream {
-    #[cfg(feature = "std")]
-    let root = quote!(::std);
-    #[cfg(not(feature = "std"))]
-    let root = quote!(::core);
-    root
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,13 +125,6 @@
 //!
 //! See [auto_enums crate](https://github.com/taiki-e/auto_enums/tree/master/derive/src/derive) for more examples.
 //!
-//! ## Crate Features
-//!
-//! * `std`
-//!   * Enabled by default.
-//!   * Generate code for `std` library.
-//!   * Disable this feature to generate code for `no_std`.
-//!
 //! ## Rust Version
 //!
 //! The current minimum required Rust version is 1.30.
@@ -152,7 +145,6 @@ mod common;
 mod error;
 mod parse;
 
-pub use self::common::std_root;
 pub use self::error::{Error, Result, *};
 pub use self::parse::*;
 


### PR DESCRIPTION
`derive_utils` can generate accurate code without `std` feature.