### PR TITLE
Weaken requirements to a number of enum variants

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -131,8 +131,8 @@ impl EnumData {
         E: MaybeEnum,
     {
         let elements = MaybeEnum::elements(maybe_enum)?;
-        if elements.variants.len() < 2 {
-            error!(maybe_enum, "cannot be implemented for enums with less than two variants");
+        if elements.variants.is_empty() {
+            error!(maybe_enum, "cannot be implemented for enums with no variants");
         }
 
         parse_variants(elements.variants).map(|(variants, fields)| Self {


### PR DESCRIPTION
Hi.

This PR is a straightforward fix for the issue where the following snippet of code won't compile with `error: cannot be implemented for enums with less than two variants`:

```rust
#[derive(Read, Write)]
enum Stream {
    Some(SomeStream),
    #[cfg(features = "other")]
    Other(OtherStream),
}
```

