### PR TITLE
Panic if an unsupported trait definition passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+* `quick_derive!`, `derive_trait`, `EnumImpl::from_trait`, `EnumImpl::push_method`, and `EnumImpl::append_items_from_trait` are now panic if an unsupported trait definition passed, instead of return error. See [#35] for details.
+
+[#35]: https://github.com/taiki-e/derive_utils/pull/35
+
 ## [0.10.0] - 2020-06-02
 
 * `quick_derive!` macro now accepts both `proc_macro2::TokenStream` and `proc_macro::TokenStream` as input.

--- a/examples/example/src/main.rs
+++ b/examples/example/src/main.rs
@@ -12,6 +12,13 @@ fn return_iter(x: i16) -> impl ExactSizeIterator<Item = i16> {
     if x < 0 { Enum::A(x..=0) } else { Enum::B(0..x) }
 }
 
+trait MyTrait1 {
+    type Assoc1;
+    type Assoc2;
+}
+
+trait MyTrait2: MyTrait1 {}
+
 fn main() {
     let iter = return_iter(-10);
     let iter2 = return_iter(10);

--- a/examples/example_derive/src/lib.rs
+++ b/examples/example_derive/src/lib.rs
@@ -49,3 +49,30 @@ pub fn derive_future(input: TokenStream) -> TokenStream {
         }
     }
 }
+
+#[proc_macro_derive(MyTrait1)]
+pub fn derive_my_trait1(input: TokenStream) -> TokenStream {
+    quick_derive! {
+        input,
+        // trait path
+        MyTrait1,
+        // trait definition
+        trait MyTrait1 {
+            type Assoc1;
+            type Assoc2;
+        }
+    }
+}
+
+#[proc_macro_derive(MyTrait2)]
+pub fn derive_my_trait2(input: TokenStream) -> TokenStream {
+    quick_derive! {
+        input,
+        // trait path
+        MyTrait2,
+        // super trait's associated types
+        <Assoc1, Assoc2>,
+        // trait definition
+        trait MyTrait2: MyTrait1 {}
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,28 +178,21 @@ macro_rules! quick_derive {
         $crate::__private::parse_input($input, |data| {
             $crate::derive_trait(
                 &data,
-                $crate::__private::parse2::<$crate::__private::Path>(
-                    $crate::__private::quote!($trait_path)
-                )?,
+                $crate::__private::parse_quote!($trait_path),
                 $crate::__private::Some($crate::__private::format_ident!(stringify!($super))),
-                $crate::__private::parse2::<$crate::__private::ItemTrait>(
-                    $crate::__private::quote!($trait_def),
-                )?,
+                $crate::__private::parse_quote!($trait_def),
             )
         })
         .into()
     };
-    ($input:expr, $trait_path:expr, <$($super:ident)+>, $trait_def:item $(,)*) => {
+    // TODO: $(,)? requires Rust 1.32.
+    ($input:expr, $trait_path:expr, <$($super:ident),+ $(,)*>, $trait_def:item $(,)*) => {
         $crate::__private::parse_input($input, |data| {
             $crate::derive_trait(
                 &data,
-                $crate::__private::parse2::<$crate::__private::Path>(
-                    $crate::__private::quote!($trait_path)
-                )?,
-                vec![$( $crate::__private::format_ident!(stringify!($super)) )+],
-                $crate::__private::parse2::<$crate::__private::ItemTrait>(
-                    $crate::__private::quote!($trait_def),
-                )?,
+                $crate::__private::parse_quote!($trait_path),
+                vec![$( $crate::__private::format_ident!(stringify!($super)) ),+],
+                $crate::__private::parse_quote!($trait_def),
             )
         })
         .into()
@@ -208,13 +201,9 @@ macro_rules! quick_derive {
         $crate::__private::parse_input($input, |data| {
             $crate::derive_trait(
                 &data,
-                $crate::__private::parse2::<$crate::__private::Path>(
-                    $crate::__private::quote!($trait_path)
-                )?,
+                $crate::__private::parse_quote!($trait_path),
                 $crate::__private::None,
-                $crate::__private::parse2::<$crate::__private::ItemTrait>(
-                    $crate::__private::quote!($trait_def),
-                )?,
+                $crate::__private::parse_quote!($trait_def),
             )
         })
         .into()
@@ -229,18 +218,17 @@ pub mod __private {
     #[doc(hidden)]
     pub use std::option::Option::{None, Some};
     #[doc(hidden)]
-    pub use syn::{parse2, ItemTrait, Path};
+    pub use syn::{parse2, parse_quote, ItemTrait, Path};
 
     use proc_macro2::TokenStream;
-    use syn::Result;
 
     use crate::EnumData;
 
     #[doc(hidden)]
     pub fn parse_input(
         input: impl Into<TokenStream>,
-        f: fn(EnumData) -> Result<TokenStream>,
+        f: fn(EnumData) -> TokenStream,
     ) -> TokenStream {
-        parse2::<EnumData>(input.into()).and_then(f).unwrap_or_else(|e| e.to_compile_error())
+        parse2::<EnumData>(input.into()).map(f).unwrap_or_else(|e| e.to_compile_error())
     }
 }


### PR DESCRIPTION
This is an error on the side of the proc-macro that uses `derive_utils` and users of the proc-macro see a useless error message. This should be clearly separated from input errors that returned by `EnumData::parse`.