### PR TITLE
Move some ui tests from auto_enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,8 @@ members = ["examples/example", "examples/example_derive"]
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1.0.7", features = ["full"] }
+
+[dev-dependencies]
+rustversion = "1"
+trybuild = "1"
+example_derive = { version = "0", path = "examples/example_derive" }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -74,19 +74,27 @@ impl Parse for EnumData {
                     return Err(error!(e, "may not be used on enums with discriminants"));
                 }
 
+                if v.fields.is_empty() {
+                    return Err(error!(
+                        v,
+                        "may not be used on enums with variants with zero fields"
+                    ));
+                } else if v.fields.len() != 1 {
+                    return Err(error!(
+                        v,
+                        "may not be used on enums with variants with multiple fields"
+                    ));
+                }
+
                 match &v.fields {
-                    Fields::Unnamed(f) => match f.unnamed.len() {
-                        1 => {
-                            field_types.push(f.unnamed.iter().next().unwrap().ty.clone());
-                            Ok(field_types)
-                        }
-                        0 => Err(error!(f, "a variant with zero fields is not supported")),
-                        _ => Err(error!(f, "a variant with multiple fields is not supported")),
-                    },
-                    Fields::Unit => Err(error!(v, "may not be used on enums with unit variants")),
-                    Fields::Named(_) => {
-                        Err(error!(v, "may not be used on enums with struct variants"))
+                    Fields::Unnamed(f) => {
+                        field_types.push(f.unnamed.iter().next().unwrap().ty.clone());
+                        Ok(field_types)
                     }
+                    Fields::Named(_) => {
+                        Err(error!(v, "may not be used on enums with variants with named fields"))
+                    }
+                    Fields::Unit => unreachable!(),
                 }
             },
         )?;

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,0 +1,14 @@
+#![warn(rust_2018_idioms, single_use_lifetimes)]
+
+use std::env;
+
+#[rustversion::attr(not(nightly), ignore)]
+#[test]
+fn ui() {
+    if !env::var_os("CI").map_or(false, |v| v == "true") {
+        env::set_var("TRYBUILD", "overwrite");
+    }
+
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/tests/ui/variant.rs
+++ b/tests/ui/variant.rs
@@ -1,0 +1,36 @@
+use example_derive::Iterator;
+
+#[derive(Iterator)]
+enum EnumWZV {} //~ ERROR may not be used on enums without variants
+
+#[derive(Iterator)]
+enum EnumWD {
+    A = 2, //~ ERROR may not be used on enums with discriminants
+    B,
+}
+
+#[derive(Iterator)]
+enum EnumWZF1<B> {
+    A, //~ ERROR may not be used on enums with variants with zero fields
+    B(B),
+}
+
+#[derive(Iterator)]
+enum EnumWZF2<B> {
+    A(), //~ ERROR may not be used on enums with variants with zero fields
+    B(B),
+}
+
+#[derive(Iterator)]
+enum EnumWMF<A, B> {
+    A(A),
+    B(A, B), //~ ERROR may not be used on enums with variants with multiple fields
+}
+
+#[derive(Iterator)]
+enum EnumWNF<A, B> {
+    A { x: A }, //~ ERROR may not be used on enums with variants with named fields
+    B(B),
+}
+
+fn main() {}

--- a/tests/ui/variant.stderr
+++ b/tests/ui/variant.stderr
@@ -1,0 +1,35 @@
+error: may not be used on enums without variants
+ --> $DIR/variant.rs:4:14
+  |
+4 | enum EnumWZV {} //~ ERROR may not be used on enums without variants
+  |              ^^
+
+error: may not be used on enums with discriminants
+ --> $DIR/variant.rs:8:9
+  |
+8 |     A = 2, //~ ERROR may not be used on enums with discriminants
+  |         ^
+
+error: may not be used on enums with variants with zero fields
+  --> $DIR/variant.rs:14:5
+   |
+14 |     A, //~ ERROR may not be used on enums with variants with zero fields
+   |     ^
+
+error: may not be used on enums with variants with zero fields
+  --> $DIR/variant.rs:20:5
+   |
+20 |     A(), //~ ERROR may not be used on enums with variants with zero fields
+   |     ^^^
+
+error: may not be used on enums with variants with multiple fields
+  --> $DIR/variant.rs:27:5
+   |
+27 |     B(A, B), //~ ERROR may not be used on enums with variants with multiple fields
+   |     ^^^^^^^
+
+error: may not be used on enums with variants with named fields
+  --> $DIR/variant.rs:32:5
+   |
+32 |     A { x: A }, //~ ERROR may not be used on enums with variants with named fields
+   |     ^^^^^^^^^^


### PR DESCRIPTION
This crate has historically been part of [`auto_enums`](https://github.com/taiki-e/auto_enums) repo, and some testing is still done by `auto_enums` repo. This increases the maintenance burden on `auto_enums` repo, so it is preferable to move it to this repo.