### PR TITLE
Remove support for `self: Pin<&(mut) Self>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,23 +57,6 @@ pub fn derive_exact_size_iterator(input: TokenStream) -> TokenStream {
         }
     }
 }
-
-#[proc_macro_derive(Future)]
-pub fn derive_future(input: TokenStream) -> TokenStream {
-    quick_derive! {
-        input,
-        // trait path
-        std::future::Future,
-        // trait definition
-        trait Future {
-            type Output;
-            fn poll(
-                self: std::pin::Pin<&mut Self>,
-                cx: &mut std::task::Context<'_>,
-            ) -> std::task::Poll<Self::Output>;
-        }
-    }
-}
 ```
 
 ### Generated code
@@ -125,26 +108,6 @@ where
         match self {
             Enum::A(x) => x.len(),
             Enum::B(x) => x.len(),
-        }
-    }
-}
-
-impl<A, B> std::future::Future for Enum<A, B>
-where
-    A: std::future::Future,
-    B: std::future::Future<Output = <A as std::future::Future>::Output>,
-{
-    type Output = <A as std::future::Future>::Output;
-
-    fn poll(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
-        unsafe {
-            match self.get_unchecked_mut() {
-                Enum::A(x) => std::pin::Pin::new_unchecked(x).poll(cx),
-                Enum::B(x) => std::pin::Pin::new_unchecked(x).poll(cx),
-            }
         }
     }
 }

--- a/examples/example/src/main.rs
+++ b/examples/example/src/main.rs
@@ -1,8 +1,8 @@
 #![warn(rust_2018_idioms, single_use_lifetimes)]
 
-use example_derive::{ExactSizeIterator, Future, Iterator};
+use example_derive::{ExactSizeIterator, Iterator};
 
-#[derive(Iterator, ExactSizeIterator, Future)]
+#[derive(Iterator, ExactSizeIterator)]
 enum Enum<A, B> {
     A(A),
     B(B),

--- a/examples/example_derive/src/lib.rs
+++ b/examples/example_derive/src/lib.rs
@@ -33,23 +33,6 @@ pub fn derive_exact_size_iterator(input: TokenStream) -> TokenStream {
     }
 }
 
-#[proc_macro_derive(Future)]
-pub fn derive_future(input: TokenStream) -> TokenStream {
-    quick_derive! {
-        input,
-        // trait path
-        std::future::Future,
-        // trait definition
-        trait Future {
-            type Output;
-            fn poll(
-                self: std::pin::Pin<&mut Self>,
-                cx: &mut std::task::Context<'_>,
-            ) -> std::task::Poll<Self::Output>;
-        }
-    }
-}
-
 #[proc_macro_derive(MyTrait1)]
 pub fn derive_my_trait1(input: TokenStream) -> TokenStream {
     quick_derive! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,25 +44,6 @@
 //!         }
 //!     }
 //! }
-//!
-//! # #[cfg(any())]
-//! #[proc_macro_derive(Future)]
-//! # pub fn _derive_future(_: TokenStream) -> TokenStream { unimplemented!() }
-//! pub fn derive_future(input: TokenStream) -> TokenStream {
-//!     quick_derive! {
-//!         input,
-//!         // trait path
-//!         std::future::Future,
-//!         // trait definition
-//!         trait Future {
-//!             type Output;
-//!             fn poll(
-//!                 self: std::pin::Pin<&mut Self>,
-//!                 cx: &mut std::task::Context<'_>,
-//!             ) -> std::task::Poll<Self::Output>;
-//!         }
-//!     }
-//! }
 //! ```
 //!
 //! ### Generated code
@@ -116,25 +97,6 @@
 //!         match self {
 //!             Enum::A(x) => x.len(),
 //!             Enum::B(x) => x.len(),
-//!         }
-//!     }
-//! }
-//!
-//! impl<A, B> std::future::Future for Enum<A, B>
-//! where
-//!     A: std::future::Future,
-//!     B: std::future::Future<Output = <A as std::future::Future>::Output>,
-//! {
-//!     type Output = <A as std::future::Future>::Output;
-//!     fn poll(
-//!         self: std::pin::Pin<&mut Self>,
-//!         cx: &mut std::task::Context<'_>,
-//!     ) -> std::task::Poll<Self::Output> {
-//!         unsafe {
-//!             match self.get_unchecked_mut() {
-//!                 Enum::A(x) => std::pin::Pin::new_unchecked(x).poll(cx),
-//!                 Enum::B(x) => std::pin::Pin::new_unchecked(x).poll(cx),
-//!             }
 //!         }
 //!     }
 //! }


### PR DESCRIPTION
In the current implementation, if a user creates their own `Unpin` or `Drop` implementation, it can cause unsoundness.

This was not a problem in the original use case where enums are anonymized (`#[auto_enum]` attribute in [`auto_enums`](https://github.com/taiki-e/auto_enums)), but it becomes a problem when users have access to enums.

I have been investigating this issue for a long time, but unfortunately, I could not find a way (other than the way of adding `Unpin` bounds) to make it work correctly in the side of derive_utils, which is used in the context of both derive and attribute macros.

Therefore, I will remove this for now.

Closes #39